### PR TITLE
Support addresses taken from sampling reports

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,22 +86,54 @@ const getAddresses = (file) => {
   const content = fs.readFileSync(file, 'utf8')
   const addresses = []
   content.split('\n').forEach((line) => {
-    const segments = line.split(/\s+/)
-    const index = parseInt(segments[0])
-    if (!isFinite(index)) return
-
-    const library = segments[1]
-    const address = segments[2]
-    const image = segments[3]
-
-    // images are of the format: 0x10eb25000
-    if (/0x[0-9a-fA-F]+/.test(image)) {
-      addresses.push({library, image, address})
+    if (line.match(/load address/)) {
+      addresses.push(parseSamplingAddress(line))
     } else {
-      addresses.push({line: segments.slice(3).join(' ')})
+      addresses.push(parseAddress(line))
     }
   })
   return addresses
+}
+
+// Lines from stack traces are of the format:
+// 0   com.github.electron.framework  0x000000010d01fad3 0x10c497000 + 12094163
+const parseAddress = (line) => {
+  const segments = line.split(/\s+/)
+  const index = parseInt(segments[0])
+  if (!isFinite(index)) return
+
+  const library = segments[1]
+  const address = segments[2]
+  const image = segments[3]
+
+  // images are of the format: 0x10eb25000
+  if (/0x[0-9a-fA-F]+/.test(image)) {
+    return {library, image, address}
+  } else {
+    return {line: segments.slice(3).join(' ')}
+  }
+}
+
+// Lines from macOS sampling reports are of the format:
+// 2189 ???  (in Electron Framework)  load address 0x1052bd000 + 0x3f8e36  [0x1056b5e36]
+const parseSamplingAddress = (line) => {
+  const isElectron = line.match(/\(in Electron Framework\)/)
+  const isNode = line.match(/\(in libnode\.dylib\)/)
+  if (!isElectron && !isNode) return
+
+  const addressMatch = line.match(/\[(0x[0-9a-fA-F]+)]/)
+  if (!addressMatch) return
+
+  const imageMatch = line.match(/(0x[0-9a-fA-F]+)/)
+  if (!imageMatch) return
+
+  const library = isElectron
+    ? 'com.github.electron.framework'
+    : 'libnode.dylib'
+  const address = addressMatch[1]
+  const image = imageMatch[1]
+
+  return {library, image, address}
 }
 
 const getLibraryPath = (rootDirectory, library) => {

--- a/test/fixtures/sampling-addresses.txt
+++ b/test/fixtures/sampling-addresses.txt
@@ -1,0 +1,3 @@
+    + !     2189 ???  (in Electron Framework)  load address 0x1052bd000 + 0x3f8e36  [0x1056b5e36]
+    + !       2189 ???  (in Electron Framework)  load address 0x1052bd000 + 0x3f9d3d  [0x1056b6d3d]
+    +       2193 ???  (in libnode.dylib)  load address 0x1096d6000 + 0x157763  [0x10982d763]

--- a/test/fixtures/sampling-symbols.txt
+++ b/test/fixtures/sampling-symbols.txt
@@ -1,0 +1,3 @@
+content::ContentMain(content::ContentMainParams const&) (in Electron Framework) (content_main.cc:20)
+content::ContentMainRunnerImpl::Run() (in Electron Framework) (content_main_runner.cc:774)
+worker (in libnode.dylib) (threadpool.c:76)

--- a/test/test.js
+++ b/test/test.js
@@ -45,4 +45,16 @@ describe('atos', function () {
       done()
     })
   })
+
+  it('returns an array of symbols for addresses taken from sampling', (done) => {
+    atos({
+      file: path.join(fixtures, 'sampling-addresses.txt'),
+      version: '1.6.8'
+    }, (error, symbols) => {
+      if (error != null) return done(error)
+
+      assert.equal(symbols.join('\n'), fs.readFileSync(path.join(fixtures, 'sampling-symbols.txt'), 'utf8').trim())
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Occasionally for performance issues we've been asking customers to open _Activity Monitor_, right-click the process and select _Sample Process_. This produces a text file with unsymbolicated addresses similar to macOS stack traces, but arranged in a different order ([example](https://github.com/kevinsawicki/electron-atos/files/1020602/Sample.of.Slack.txt)). This PR just extends the parsing logic so that we can support lines in both formats.
